### PR TITLE
docs: readme update for aur support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ brew install dgr8akki/tap/nano-ffmpeg
 
 Homebrew installs `ffmpeg-full` as a dependency for the tap formula.
 
+**Arch Linux (AUR):**
+
+```bash
+yay -S nano-ffmpeg
+```
+
 **Download binary:**
 
 Grab a prebuilt binary from [GitHub Releases](https://github.com/dgr8akki/nano-ffmpeg/releases/latest) for your platform (macOS, Linux, Windows).


### PR DESCRIPTION
This pull request resolves #3, updating the installation instructions in the `README.md` to include Arch Linux using the AUR (`yay`).

Installation documentation update:

* Added instructions for installing `nano-ffmpeg` on Arch Linux via the AUR using `yay -S nano-ffmpeg`.