### PR TITLE
fix(ffmpeg): windows ffmpeg detection

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ website/node_modules/
 website/.next/
 website/out/
 docs/
+
+# nix
+result
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "flakelight": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1774878311,
+        "narHash": "sha256-Ou5sDaR9GydAbxJYY50fqaFYYQCwUMOwSOdTBcgy47g=",
+        "owner": "nix-community",
+        "repo": "flakelight",
+        "rev": "06ee2d1a00324727c75f1c279c4ede0d871d110d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flakelight",
+        "type": "github"
+      }
+    },
+    "flakelight-go": {
+      "inputs": {
+        "flakelight": "flakelight"
+      },
+      "locked": {
+        "lastModified": 1775256861,
+        "narHash": "sha256-rkwvE3a2AcuPSpI9QsLRTNt3OJEusW2LMsfFCPmqdOg=",
+        "owner": "chikof",
+        "repo": "flakelight-go",
+        "rev": "33b0fc81b2af1ec62c316f6a57a5f6097facfc53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "chikof",
+        "repo": "flakelight-go",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flakelight-go": "flakelight-go"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,7 @@
+{
+  inputs.flakelight-go.url = "github:chikof/flakelight-go";
+  outputs = {flakelight-go, ...}:
+    flakelight-go ./. {
+      go.version = 26;
+    };
+}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,14 @@ module github.com/dgr8akki/nano-ffmpeg
 go 1.26.1
 
 require (
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/spf13/cobra v1.10.2
+)
+
+require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbles v1.0.0 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
@@ -24,7 +27,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
-github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
-github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco3ej+ngLk1kk=
@@ -49,6 +47,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=

--- a/internal/ffmpeg/detect.go
+++ b/internal/ffmpeg/detect.go
@@ -49,13 +49,13 @@ func findBinary(name string) (string, error) {
 		return path, nil
 	}
 
-	if runtime.GOOS == "windows" {
-		return findNextToExecutable(name, ".exe")
+	if p, err := findNextToExecutable(name); err == nil {
+		return p, nil
 	}
 
 	// Fallback to common and keg-only Homebrew locations.
 	for _, p := range fallbackBinaryPaths(name) {
-		if fileExists(p) {
+		if _, err := exec.LookPath(p); err == nil {
 			return p, nil
 		}
 	}
@@ -103,26 +103,29 @@ func parseVersion(ffmpegPath string) (version, buildConfig string, err error) {
 	return version, buildConfig, nil
 }
 
-func findNextToExecutable(name, suffix string) (string, error) {
+func findNextToExecutable(name string) (string, error) {
 	exePath, err := os.Executable()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("could not determine executable path: %w", err)
 	}
 
-	exePath, err = filepath.EvalSymlinks(exePath)
-	if err != nil {
-		return "", err
+	if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
+		exePath = resolved
 	}
 
-	candidate := filepath.Join(filepath.Dir(exePath), name+suffix)
+	candidate := filepath.Join(filepath.Dir(exePath), name)
+	if runtime.GOOS == "windows" {
+		candidate += ".exe"
+	}
+
 	if fileExists(candidate) {
 		return candidate, nil
 	}
 
-	return "", fmt.Errorf("not found next to executable")
+	return "", fmt.Errorf("%s not found next to executable (tried %s)", name, candidate)
 }
 
 func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
 }

--- a/internal/ffmpeg/detect.go
+++ b/internal/ffmpeg/detect.go
@@ -2,8 +2,11 @@ package ffmpeg
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 )
 
@@ -42,13 +45,17 @@ func Detect() (*Info, error) {
 
 func findBinary(name string) (string, error) {
 	// Try PATH first
-	path, err := exec.LookPath(name)
-	if err == nil {
+	if path, err := exec.LookPath(name); err == nil {
 		return path, nil
 	}
+
+	if runtime.GOOS == "windows" {
+		return findNextToExecutable(name, ".exe")
+	}
+
 	// Fallback to common and keg-only Homebrew locations.
 	for _, p := range fallbackBinaryPaths(name) {
-		if _, err := exec.LookPath(p); err == nil {
+		if fileExists(p) {
 			return p, nil
 		}
 	}
@@ -94,4 +101,28 @@ func parseVersion(ffmpegPath string) (version, buildConfig string, err error) {
 	}
 
 	return version, buildConfig, nil
+}
+
+func findNextToExecutable(name, suffix string) (string, error) {
+	exePath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	exePath, err = filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return "", err
+	}
+
+	candidate := filepath.Join(filepath.Dir(exePath), name+suffix)
+	if fileExists(candidate) {
+		return candidate, nil
+	}
+
+	return "", fmt.Errorf("not found next to executable")
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }


### PR DESCRIPTION
- Add nix flake for development (thank me later nix devs)
- Fix Windows ffmpeg detection: probe next to executable with .exe suffix instead of relying solely on PATH
- Ran `go mod tidy`

This PR fixes #1 

It seems that Go behaves strangely on Windows. To get it to find the binary file in the directory where `nano-ffmpeg` is run, you have to explicitly tell it to search the current directory: `exec.LookPath("./ffmpeg")`. This was the only way I could get it to work without having to make any modifications, which isn't the right way to do it.

> Shout out to @ulysses-ck for helping me test on windows