### PR TITLE
fix(filepicker): follow directory symlinks when listing entries

### DIFF
--- a/internal/screens/filepicker/filepicker.go
+++ b/internal/screens/filepicker/filepicker.go
@@ -328,7 +328,7 @@ func (m *Model) KeyHints() []ui.KeyHint {
 }
 
 func (m *Model) loadDir() {
-	entries, err := os.ReadDir(m.currentDir)
+	raw, err := os.ReadDir(m.currentDir)
 	if err != nil {
 		m.err = err
 		return
@@ -336,36 +336,41 @@ func (m *Model) loadDir() {
 
 	m.entries = nil
 
-	// Directories first
-	for _, e := range entries {
+	type resolved struct {
+		name  string
+		path  string
+		isDir bool
+		size  int64
+	}
+	var items []resolved
+	for _, e := range raw {
 		if strings.HasPrefix(e.Name(), ".") {
 			continue
 		}
-		if e.IsDir() {
-			m.entries = append(m.entries, entry{
-				name:  e.Name(),
-				path:  filepath.Join(m.currentDir, e.Name()),
-				isDir: true,
-			})
-		}
-	}
-
-	// Then files (media files highlighted)
-	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), ".") || e.IsDir() {
+		path := filepath.Join(m.currentDir, e.Name())
+		// Stat follows symlinks so directory symlinks are browsable; broken
+		// symlinks return an error and are skipped.
+		info, err := os.Stat(path)
+		if err != nil {
 			continue
 		}
-		info, _ := e.Info()
-		var size int64
-		if info != nil {
-			size = info.Size()
-		}
-		m.entries = append(m.entries, entry{
+		items = append(items, resolved{
 			name:  e.Name(),
-			path:  filepath.Join(m.currentDir, e.Name()),
-			isDir: false,
-			size:  size,
+			path:  path,
+			isDir: info.IsDir(),
+			size:  info.Size(),
 		})
+	}
+
+	for _, it := range items {
+		if it.isDir {
+			m.entries = append(m.entries, entry{name: it.name, path: it.path, isDir: true})
+		}
+	}
+	for _, it := range items {
+		if !it.isDir {
+			m.entries = append(m.entries, entry{name: it.name, path: it.path, isDir: false, size: it.size})
+		}
 	}
 }
 

--- a/internal/screens/filepicker/filepicker_test.go
+++ b/internal/screens/filepicker/filepicker_test.go
@@ -333,3 +333,57 @@ func TestFilepickerVisibleLines_FloorEnforced(t *testing.T) {
 		t.Fatalf("expected visible lines >= 5, got %d", got)
 	}
 }
+
+func TestFilepickerLoadDir_FollowsDirectorySymlinks(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "real")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "clip.mp4"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write inside target: %v", err)
+	}
+
+	browse := t.TempDir()
+	link := filepath.Join(browse, "videos")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	m := New("ffprobe", browse)
+	if len(m.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %+v", len(m.entries), m.entries)
+	}
+	if !m.entries[0].isDir {
+		t.Fatalf("symlinked directory should be marked isDir: %+v", m.entries[0])
+	}
+
+	s, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = s.(*Model)
+	if m.currentDir != link {
+		t.Fatalf("expected to enter %q, got %q", link, m.currentDir)
+	}
+	if len(m.entries) != 1 || m.entries[0].name != "clip.mp4" {
+		t.Fatalf("expected to list target contents, got %+v", m.entries)
+	}
+}
+
+func TestFilepickerLoadDir_SkipsBrokenSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "missing-target"), filepath.Join(dir, "broken")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ok.mp4"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	m := New("ffprobe", dir)
+	for _, e := range m.entries {
+		if e.name == "broken" {
+			t.Fatalf("broken symlink should be skipped, got entries: %+v", m.entries)
+		}
+	}
+	if len(m.entries) != 1 || m.entries[0].name != "ok.mp4" {
+		t.Fatalf("expected only ok.mp4, got %+v", m.entries)
+	}
+}


### PR DESCRIPTION
## Problem
 The filepicker uses os.DirEntry.IsDir(), which returns false for
 symlinks regardless of the target type. Symlinked directories
 appear as un-enterable entries.

## Fix
Resolve each entry with os.Stat() so the symlink target's type is
used. Broken symlinks are skipped silently.

## Tests
 - TestFilepickerLoadDir_FollowsDirectorySymlinks
 - TestFilepickerLoadDir_SkipsBrokenSymlinks