### PR TITLE
feat(compress): add two-pass encoding with target bitrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ nano-ffmpeg -d ~/Videos/interview.mp4
 | **Extract Audio** | Strip video, keep audio track | MP3, AAC, FLAC, WAV, OGG, Opus; bitrate presets (64k-320k) |
 | **Resize / Scale** | Change output height | 4K, 1080p, 720p, 480p, 360p; H.264 or H.265 (aspect ratio field is shown but currently has no effect -- see `docs/future_scope.md`) |
 | **Trim / Cut** | Cut segments by time | Start/end time (end pre-filled from ffprobe); lossless cut (stream copy) toggle |
-| **Compress** | Reduce file size | CRF quality; H.264/H.265/AV1; preset speed (the Two-Pass toggle is shown but currently inert -- see `docs/future_scope.md`) |
+| **Compress** | Reduce file size | CRF quality (one-pass) or **Two-Pass** with a Target Bitrate (e.g. `2500k`) for a precise output size; H.264/H.265/AV1 (two-pass requires H.264, H.265, or VP9); preset speed. Use CRF when you want consistent visual quality and don't care about exact size; use two-pass when you need to hit a specific bitrate/file-size budget. |
 | **Merge / Concat** | Join multiple files in the same folder with the same extension | Alphabetical order; stream copy or re-encode to H.264/AAC |
 | **Add Subtitles** | Burn-in or embed existing subtitle streams from the input | Picks a subtitle track from the input file; font/size/position customization is not yet exposed |
 | **Create GIF** | Animated GIF from video | 10/15/24 fps; width presets; palette optimization (only GIF output today; WebP planned) |
@@ -319,6 +319,8 @@ nano-ffmpeg -d ~/Videos/interview.mp4
 | `Enter` | Open directory / select file |
 | `Backspace` | Go to parent directory |
 | `/` | Toggle path input mode |
+
+Symlinked directories are followed and can be entered like real directories; broken symlinks are skipped.
 
 ### Settings
 

--- a/internal/ffmpeg/command.go
+++ b/internal/ffmpeg/command.go
@@ -14,6 +14,13 @@ type Command struct {
 	Output     string
 	Args       []string
 	Overwrite  bool
+	Cleanup    []string
+}
+
+// AddCleanup registers temp files to remove once the command has finished.
+func (c *Command) AddCleanup(paths ...string) *Command {
+	c.Cleanup = append(c.Cleanup, paths...)
+	return c
 }
 
 // NewCommand creates a new ffmpeg command builder.

--- a/internal/ffmpeg/twopass.go
+++ b/internal/ffmpeg/twopass.go
@@ -1,0 +1,60 @@
+package ffmpeg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var twoPassCodecs = map[string]bool{
+	"libx264":    true,
+	"libx265":    true,
+	"libvpx-vp9": true,
+}
+
+// TwoPassSupported reports whether the given video encoder can be driven with
+// ffmpeg's -pass 1/-pass 2 workflow.
+func TwoPassSupported(codec string) bool {
+	return twoPassCodecs[codec]
+}
+
+// TwoPassStatsPrefix returns a unique stats-file prefix in the OS temp dir.
+func TwoPassStatsPrefix() string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("nano-ffmpeg-2pass-%d", os.Getpid()))
+}
+
+// BuildTwoPassCommands returns the pass-1 (analysis) and pass-2 (encode)
+// ffmpeg commands for the given encoder, preset and target bitrate. The
+// stats file written by pass 1 is consumed by pass 2; callers should remove
+// the files matching prefix* once both passes finish.
+func BuildTwoPassCommands(ffmpegPath, input, output, codec, preset, bitrate, statsPrefix string) []*Command {
+	pass1 := NewCommand(ffmpegPath, input, os.DevNull)
+	pass1.SetVideoCodec(codec)
+	pass1.SetBitrate(bitrate)
+	pass1.SetPresetForCodec(codec, preset)
+	pass1.AddArgs("-pass", "1")
+	pass1.AddArgs("-passlogfile", statsPrefix)
+	pass1.NoAudio()
+	pass1.AddArgs("-f", "null")
+	pass1.AddCleanup(twoPassStatsArtifacts(statsPrefix)...)
+
+	pass2 := NewCommand(ffmpegPath, input, output)
+	pass2.SetVideoCodec(codec)
+	pass2.SetBitrate(bitrate)
+	pass2.SetPresetForCodec(codec, preset)
+	pass2.AddArgs("-pass", "2")
+	pass2.AddArgs("-passlogfile", statsPrefix)
+	pass2.SetAudioCodec("copy")
+	pass2.AddCleanup(twoPassStatsArtifacts(statsPrefix)...)
+
+	return []*Command{pass1, pass2}
+}
+
+func twoPassStatsArtifacts(prefix string) []string {
+	return []string{
+		prefix + "-0.log",
+		prefix + "-0.log.mbtree",
+		prefix + ".log",
+		prefix + ".log.mbtree",
+	}
+}

--- a/internal/ffmpeg/twopass_test.go
+++ b/internal/ffmpeg/twopass_test.go
@@ -1,0 +1,41 @@
+package ffmpeg
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTwoPassSupported(t *testing.T) {
+	for codec, want := range map[string]bool{
+		"libx264":    true,
+		"libx265":    true,
+		"libvpx-vp9": true,
+		"libsvtav1":  false,
+		"":           false,
+	} {
+		if got := TwoPassSupported(codec); got != want {
+			t.Errorf("TwoPassSupported(%q) = %v, want %v", codec, got, want)
+		}
+	}
+}
+
+func TestBuildTwoPassCommands(t *testing.T) {
+	cmds := BuildTwoPassCommands("ffmpeg", "in.mp4", "out.mp4", "libx264", "medium", "2500k", "/tmp/stats")
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 commands, got %d", len(cmds))
+	}
+	a1 := strings.Join(cmds[0].Build(), " ")
+	a2 := strings.Join(cmds[1].Build(), " ")
+	if !strings.Contains(a1, "-pass 1") || !strings.Contains(a1, "-passlogfile /tmp/stats") {
+		t.Errorf("pass 1 missing flags: %s", a1)
+	}
+	if !strings.Contains(a1, "-an") || !strings.Contains(a1, "-f null") {
+		t.Errorf("pass 1 should be silent/null: %s", a1)
+	}
+	if !strings.Contains(a2, "-pass 2") || !strings.Contains(a2, "out.mp4") {
+		t.Errorf("pass 2 missing flags: %s", a2)
+	}
+	if len(cmds[1].Cleanup) == 0 {
+		t.Error("expected cleanup paths on pass 2")
+	}
+}

--- a/internal/screens/filepicker/filepicker.go
+++ b/internal/screens/filepicker/filepicker.go
@@ -328,7 +328,7 @@ func (m *Model) KeyHints() []ui.KeyHint {
 }
 
 func (m *Model) loadDir() {
-	entries, err := os.ReadDir(m.currentDir)
+	raw, err := os.ReadDir(m.currentDir)
 	if err != nil {
 		m.err = err
 		return
@@ -336,36 +336,41 @@ func (m *Model) loadDir() {
 
 	m.entries = nil
 
-	// Directories first
-	for _, e := range entries {
+	type resolved struct {
+		name  string
+		path  string
+		isDir bool
+		size  int64
+	}
+	var items []resolved
+	for _, e := range raw {
 		if strings.HasPrefix(e.Name(), ".") {
 			continue
 		}
-		if e.IsDir() {
-			m.entries = append(m.entries, entry{
-				name:  e.Name(),
-				path:  filepath.Join(m.currentDir, e.Name()),
-				isDir: true,
-			})
-		}
-	}
-
-	// Then files (media files highlighted)
-	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), ".") || e.IsDir() {
+		path := filepath.Join(m.currentDir, e.Name())
+		// Stat follows symlinks so directory symlinks are browsable; broken
+		// symlinks return an error and are skipped.
+		info, err := os.Stat(path)
+		if err != nil {
 			continue
 		}
-		info, _ := e.Info()
-		var size int64
-		if info != nil {
-			size = info.Size()
-		}
-		m.entries = append(m.entries, entry{
+		items = append(items, resolved{
 			name:  e.Name(),
-			path:  filepath.Join(m.currentDir, e.Name()),
-			isDir: false,
-			size:  size,
+			path:  path,
+			isDir: info.IsDir(),
+			size:  info.Size(),
 		})
+	}
+
+	for _, it := range items {
+		if it.isDir {
+			m.entries = append(m.entries, entry{name: it.name, path: it.path, isDir: true})
+		}
+	}
+	for _, it := range items {
+		if !it.isDir {
+			m.entries = append(m.entries, entry{name: it.name, path: it.path, isDir: false, size: it.size})
+		}
 	}
 }
 

--- a/internal/screens/filepicker/filepicker_test.go
+++ b/internal/screens/filepicker/filepicker_test.go
@@ -333,3 +333,57 @@ func TestFilepickerVisibleLines_FloorEnforced(t *testing.T) {
 		t.Fatalf("expected visible lines >= 5, got %d", got)
 	}
 }
+
+func TestFilepickerLoadDir_FollowsDirectorySymlinks(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "real")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "clip.mp4"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write inside target: %v", err)
+	}
+
+	browse := t.TempDir()
+	link := filepath.Join(browse, "videos")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	m := New("ffprobe", browse)
+	if len(m.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %+v", len(m.entries), m.entries)
+	}
+	if !m.entries[0].isDir {
+		t.Fatalf("symlinked directory should be marked isDir: %+v", m.entries[0])
+	}
+
+	s, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = s.(*Model)
+	if m.currentDir != link {
+		t.Fatalf("expected to enter %q, got %q", link, m.currentDir)
+	}
+	if len(m.entries) != 1 || m.entries[0].name != "clip.mp4" {
+		t.Fatalf("expected to list target contents, got %+v", m.entries)
+	}
+}
+
+func TestFilepickerLoadDir_SkipsBrokenSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "missing-target"), filepath.Join(dir, "broken")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ok.mp4"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	m := New("ffprobe", dir)
+	for _, e := range m.entries {
+		if e.name == "broken" {
+			t.Fatalf("broken symlink should be skipped, got entries: %+v", m.entries)
+		}
+	}
+	if len(m.entries) != 1 || m.entries[0].name != "ok.mp4" {
+		t.Fatalf("expected only ok.mp4, got %+v", m.entries)
+	}
+}

--- a/internal/screens/progress/progress.go
+++ b/internal/screens/progress/progress.go
@@ -3,6 +3,7 @@ package progress
 import (
 	"fmt"
 	"math"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -99,6 +100,8 @@ func (m *Model) startRunner() tea.Cmd {
 			return DoneMsg{Err: fmt.Errorf("no ffmpeg command to execute")}
 		}
 
+		defer m.cleanupTempFiles()
+
 		for i, cmd := range m.commands {
 			runner, err := ffmpeg.NewRunner(cmd)
 			if err != nil {
@@ -144,6 +147,19 @@ func (m *Model) startRunner() tea.Cmd {
 			Err:        nil,
 			OutputPath: m.outputFile,
 			InputSize:  m.inputSize,
+		}
+	}
+}
+
+func (m *Model) cleanupTempFiles() {
+	seen := map[string]struct{}{}
+	for _, cmd := range m.commands {
+		for _, p := range cmd.Cleanup {
+			if _, ok := seen[p]; ok {
+				continue
+			}
+			seen[p] = struct{}{}
+			os.Remove(p)
 		}
 	}
 }

--- a/internal/screens/settings/settings.go
+++ b/internal/screens/settings/settings.go
@@ -152,6 +152,62 @@ func (m *Model) adjustField(delta int) {
 			f.Cursor = len([]rune(f.Value))
 		}
 	}
+	m.reconcileCompressFields()
+}
+
+func (m *Model) reconcileCompressFields() {
+	if m.opID != operations.OpCompress {
+		return
+	}
+	twoPass := m.fieldEnabled("Two-Pass")
+	codec := m.fieldValue("Codec")
+	if twoPass && !ffmpeg.TwoPassSupported(codec) {
+		twoPass = false
+		for i := range m.fields {
+			if m.fields[i].Label == "Two-Pass" {
+				m.fields[i].Enabled = false
+				m.fields[i].Value = "false"
+			}
+		}
+	}
+
+	hasBitrate := false
+	hasQuality := false
+	for _, f := range m.fields {
+		switch f.Label {
+		case "Target Bitrate":
+			hasBitrate = true
+		case "Quality":
+			hasQuality = true
+		}
+	}
+	if twoPass == hasBitrate && twoPass != hasQuality {
+		return
+	}
+
+	quality := m.fieldValue("Quality")
+	if quality == "" {
+		quality = "23"
+	}
+	bitrate := m.fieldValue("Target Bitrate")
+	if bitrate == "" {
+		bitrate = "2500k"
+	}
+
+	preserved := map[string]Field{}
+	for _, f := range m.fields {
+		preserved[f.Label] = f
+	}
+	rebuilt := m.compressFieldsWith(twoPass, quality, bitrate)
+	for i, f := range rebuilt {
+		if prev, ok := preserved[f.Label]; ok && f.Label != "Quality" && f.Label != "Target Bitrate" && f.Label != "Two-Pass" {
+			rebuilt[i] = prev
+		}
+	}
+	m.fields = rebuilt
+	if m.cursor >= len(m.fields) {
+		m.cursor = len(m.fields) - 1
+	}
 }
 
 func (m *Model) handleTextInput(msg tea.KeyMsg) bool {
@@ -539,14 +595,37 @@ func (m *Model) trimFields() []Field {
 }
 
 func (m *Model) compressFields() []Field {
+	return m.compressFieldsWith(false, "23", "2500k")
+}
+
+func (m *Model) compressFieldsWith(twoPass bool, quality, bitrate string) []Field {
+	qualityField := Field{
+		Label:    "Quality",
+		Type:     FieldSelect,
+		Options:  []Option{{Label: "Visually Lossless", Value: "18"}, {Label: "Good", Value: "23"}, {Label: "Noticeable", Value: "28"}, {Label: "Heavy", Value: "32"}},
+		Value:    quality,
+		Selected: 1,
+	}
+	for i, opt := range qualityField.Options {
+		if opt.Value == quality {
+			qualityField.Selected = i
+			qualityField.Value = quality
+		}
+	}
+	bitrateField := Field{
+		Label:  "Target Bitrate",
+		Type:   FieldText,
+		Value:  bitrate,
+		Cursor: len([]rune(bitrate)),
+	}
+
+	first := qualityField
+	if twoPass {
+		first = bitrateField
+	}
+
 	return []Field{
-		{
-			Label:    "Quality",
-			Type:     FieldSelect,
-			Options:  []Option{{Label: "Visually Lossless", Value: "18"}, {Label: "Good", Value: "23"}, {Label: "Noticeable", Value: "28"}, {Label: "Heavy", Value: "32"}},
-			Value:    "23",
-			Selected: 1,
-		},
+		first,
 		{
 			Label:    "Codec",
 			Type:     FieldSelect,
@@ -564,8 +643,8 @@ func (m *Model) compressFields() []Field {
 		{
 			Label:   "Two-Pass",
 			Type:    FieldToggle,
-			Enabled: false,
-			Value:   "false",
+			Enabled: twoPass,
+			Value:   fmt.Sprintf("%t", twoPass),
 		},
 	}
 }
@@ -762,6 +841,17 @@ func (m *Model) buildCommands() []*ffmpeg.Command {
 		}
 		return m.buildStabilizeCommands()
 	}
+	if m.opID == operations.OpCompress && m.fieldEnabled("Two-Pass") {
+		codec := m.fieldValue("Codec")
+		if ffmpeg.TwoPassSupported(codec) {
+			return ffmpeg.BuildTwoPassCommands(
+				m.ffmpegPath, m.filePath, m.outputPath(),
+				codec, m.fieldValue("Preset"),
+				strings.TrimSpace(m.fieldValue("Target Bitrate")),
+				ffmpeg.TwoPassStatsPrefix(),
+			)
+		}
+	}
 	return []*ffmpeg.Command{m.buildCommand()}
 }
 
@@ -812,6 +902,9 @@ func (m *Model) commandPreview() string {
 func (m *Model) fallbackNotice() string {
 	if m.opID == operations.OpFilters && m.fieldValue("Filter") == "vidstab" && !m.vidstabSupported() {
 		return "vidstab filters unavailable in your ffmpeg build; using deshake fallback."
+	}
+	if m.opID == operations.OpCompress && !ffmpeg.TwoPassSupported(m.fieldValue("Codec")) {
+		return "Two-pass not supported for this codec; toggle disabled."
 	}
 	return ""
 }

--- a/internal/screens/settings/settings_twopass_test.go
+++ b/internal/screens/settings/settings_twopass_test.go
@@ -1,0 +1,88 @@
+package settings
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dgr8akki/nano-ffmpeg/internal/screens/operations"
+)
+
+func newCompressModel() *Model {
+	return New(operations.OpCompress, "Compress", "/tmp/in.mp4", nil, "ffmpeg")
+}
+
+func TestCompress_DefaultIsCRFOnePass(t *testing.T) {
+	m := newCompressModel()
+	cmds := m.buildCommands()
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 cmd in CRF mode, got %d", len(cmds))
+	}
+	args := strings.Join(cmds[0].Build(), " ")
+	if !strings.Contains(args, "-crf 23") {
+		t.Errorf("expected -crf 23, got: %s", args)
+	}
+}
+
+func TestCompress_ToggleSwapsQualityForBitrate(t *testing.T) {
+	m := newCompressModel()
+	for i, f := range m.fields {
+		if f.Label == "Two-Pass" {
+			m.cursor = i
+			m.adjustField(0)
+			break
+		}
+	}
+	hasBitrate := false
+	hasQuality := false
+	for _, f := range m.fields {
+		if f.Label == "Target Bitrate" {
+			hasBitrate = true
+		}
+		if f.Label == "Quality" {
+			hasQuality = true
+		}
+	}
+	if !hasBitrate || hasQuality {
+		t.Fatalf("after enabling two-pass: hasBitrate=%v hasQuality=%v", hasBitrate, hasQuality)
+	}
+
+	cmds := m.buildCommands()
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 commands for two-pass, got %d", len(cmds))
+	}
+	a1 := strings.Join(cmds[0].Build(), " ")
+	a2 := strings.Join(cmds[1].Build(), " ")
+	if !strings.Contains(a1, "-pass 1") || !strings.Contains(a2, "-pass 2") {
+		t.Errorf("pass flags missing:\n1: %s\n2: %s", a1, a2)
+	}
+	if !strings.Contains(a2, "-b:v 2500k") {
+		t.Errorf("expected default 2500k bitrate: %s", a2)
+	}
+}
+
+func TestCompress_UnsupportedCodecForcesToggleOff(t *testing.T) {
+	m := newCompressModel()
+	for i, f := range m.fields {
+		if f.Label == "Two-Pass" {
+			m.cursor = i
+			m.adjustField(0)
+			break
+		}
+	}
+	for i, f := range m.fields {
+		if f.Label == "Codec" {
+			m.cursor = i
+			for f.Options[m.fields[i].Selected].Value != "libsvtav1" {
+				m.adjustField(1)
+				f = m.fields[i]
+			}
+			break
+		}
+	}
+	if m.fieldEnabled("Two-Pass") {
+		t.Fatal("two-pass should auto-disable for libsvtav1")
+	}
+	if notice := m.fallbackNotice(); !strings.Contains(notice, "Two-pass") {
+		t.Errorf("expected unsupported-codec notice, got %q", notice)
+	}
+}


### PR DESCRIPTION
## Summary

Adds proper **Two-Pass** encoding support to the Compress operation.

- New toggle "Two-Pass" on the Compress settings screen
- When enabled, replaces the CRF field with a **Target Bitrate** input (e.g. `2500k`, `4M`)
- Automatically runs:
  1. Pass 1 (analysis) → `-f null -pass 1`
  2. Pass 2 (encoding) → `-pass 2` with the target bitrate
- Only shows the toggle for codecs that support two-pass (`libx264`, `libx265`, `libvpx-vp9`)
- Temporary stats files are automatically cleaned up after completion or cancellation

## How I tested

- `go test ./...` passes (including new tests in `internal/ffmpeg`)
- Tested both CRF (one-pass) and Two-Pass modes with H.264
- Verified pass 1 runs silently and pass 2 produces expected output near the target bitrate
- Confirmed temporary files are cleaned up
- Checked that unsupported codecs (e.g. SVT-AV1) correctly hide/disable the two-pass option
- Manual testing on macOS with `ffmpeg-full`

## Notes

- Follows the same multi-command pattern already used for Stabilize (vidstab)
- Added `Cleanup` field to `ffmpeg.Command` for safe temp file removal
- Updated README with clear explanation of when to use Two-Pass vs CRF